### PR TITLE
uart_fix

### DIFF
--- a/boards/shields/nrf54l15dk_arduino_adapter/nrf54l15dk_arduino_adapter.overlay
+++ b/boards/shields/nrf54l15dk_arduino_adapter/nrf54l15dk_arduino_adapter.overlay
@@ -52,13 +52,13 @@ arduino_i2c: &i2c20 {
 };
 
 /* Arduino UART mapping to nrf54l15dk UART21 */
-arduino_serial: &uart21 {
-    status = "okay";
-    current-speed = <115200>;
-    pinctrl-0 = <&uart21_default_alt>;
-    pinctrl-1 = <&uart21_sleep_alt>;
-    pinctrl-names = "default", "sleep";
-};
+// arduino_serial: &uart21 {
+//     status = "okay";
+//     current-speed = <115200>;
+//     pinctrl-0 = <&uart21_default_alt>;
+//     pinctrl-1 = <&uart21_sleep_alt>;
+//     pinctrl-names = "default", "sleep";
+// };
 
 /* Pin control configurations */
 &pinctrl {
@@ -97,20 +97,20 @@ arduino_serial: &uart21 {
     };
 
     /* UART pin configuration */
-    uart21_default_alt: uart21_default_alt {
-        group1 {
-            psels = <NRF_PSEL(UART_TX, 0, 6)>,    /* D14 - TX */
-                <NRF_PSEL(UART_RX, 0, 7)>;        /* D15 - RX */
-        };
-    };
+    // uart21_default_alt: uart21_default_alt {
+    //     group1 {
+    //         psels = <NRF_PSEL(UART_TX, 0, 6)>,    /* D14 - TX */
+    //             <NRF_PSEL(UART_RX, 0, 7)>;        /* D15 - RX */
+    //     };
+    // };
 
-    uart21_sleep_alt: uart21_sleep_alt {
-        group1 {
-            psels = <NRF_PSEL(UART_TX, 0, 6)>,
-                <NRF_PSEL(UART_RX, 0, 7)>;
-            low-power-enable;
-        };
-    };
+    // uart21_sleep_alt: uart21_sleep_alt {
+    //     group1 {
+    //         psels = <NRF_PSEL(UART_TX, 0, 6)>,
+    //             <NRF_PSEL(UART_RX, 0, 7)>;
+    //         low-power-enable;
+    //     };
+    // };
 }; 
 
 / {
@@ -119,8 +119,19 @@ arduino_serial: &uart21 {
         smtc-hal-uart = &uart20;
         smtc-watchdog = &wdt31;
     };
+
+    zephyr,user {
+        /* PINS used for the HW modem sample. */
+        hw-modem-command-gpios = <&gpio1 8  (GPIO_ACTIVE_HIGH|GPIO_PULL_UP)>;
+        hw-modem-busy-gpios =  <&gpio1 9 GPIO_ACTIVE_HIGH>;
+        hw-modem-event-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+        hw-modem-led-scan-gpios =<&gpio1 12 GPIO_ACTIVE_HIGH>;
+    };
 };
 
+&uart20 {
+	/delete-property/ hw-flow-control;
+};
 
 /* Configuration needed for LR1110 module on nrf54 boards */
 

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: zephyr
       url: https://github.com/zephyrproject-rtos/zephyr
-      revision: v3.7.0
+      revision: v4.1.0
       import: true
 
     - name: lora_basics_modem

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: zephyr
       url: https://github.com/zephyrproject-rtos/zephyr
-      revision: v4.1.0
+      revision: v3.7.0
       import: true
 
     - name: lora_basics_modem

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: zephyr
       url: https://github.com/zephyrproject-rtos/zephyr
-      revision: v3.9.0
+      revision: 81a2b95a7e78217ec0ec0173a0dc9bcc4447ea5e
       import: true
 
     - name: lora_basics_modem

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: zephyr
       url: https://github.com/zephyrproject-rtos/zephyr
-      revision: v3.7.0
+      revision: v3.8.0
       import: true
 
     - name: lora_basics_modem

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: zephyr
       url: https://github.com/zephyrproject-rtos/zephyr
-      revision: v3.8.0
+      revision: v3.9.0
       import: true
 
     - name: lora_basics_modem

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: zephyr
       url: https://github.com/zephyrproject-rtos/zephyr
-      revision: v3.9.0
+      revision: v4.0.0
       import: true
 
     - name: lora_basics_modem

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: zephyr
       url: https://github.com/zephyrproject-rtos/zephyr
-      revision: 81a2b95a7e78217ec0ec0173a0dc9bcc4447ea5e
+      revision: v3.9.0
       import: true
 
     - name: lora_basics_modem


### PR DESCRIPTION
Bumped zephyr version to 4.1
Updated device tree overlay to work with hw_modem sample
disabled hw_flow_control
commented out uart21 (not used for samples) because it interfered with uart 20